### PR TITLE
[BUGFIX] Cannot access protected property in fluid

### DIFF
--- a/Classes/Domain/Model/AbstractModel.php
+++ b/Classes/Domain/Model/AbstractModel.php
@@ -23,12 +23,12 @@ abstract class AbstractModel extends AbstractEntity
     /**
      * @var int
      */
-    protected $tstamp;
+    protected $tstamp = 0;
 
     /**
      * @var int
      */
-    protected $crdate;
+    protected $crdate = 0;
 
     /**
      * @return int

--- a/Classes/Domain/Model/AbstractModel.php
+++ b/Classes/Domain/Model/AbstractModel.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 abstract class AbstractModel extends AbstractEntity
 {
-
     /**
      * @var int
      */
@@ -34,7 +33,8 @@ abstract class AbstractModel extends AbstractEntity
     /**
      * @return int
      */
-    public function getTstamp(): int {
+    public function getTstamp(): int
+    {
         return $this->tstamp;
     }
 
@@ -42,7 +42,8 @@ abstract class AbstractModel extends AbstractEntity
      * @param int $tstamp
      * @return self
      */
-    public function setTstamp($tstamp) {
+    public function setTstamp($tstamp)
+    {
         $this->tstamp = $tstamp;
         return $this;
     }
@@ -50,7 +51,8 @@ abstract class AbstractModel extends AbstractEntity
     /**
      * @return int
      */
-    public function getCrdate(): int {
+    public function getCrdate(): int
+    {
         return $this->crdate;
     }
 
@@ -58,9 +60,9 @@ abstract class AbstractModel extends AbstractEntity
      * @param int $crdate
      * @return self
      */
-    public function setCrdate($crdate) {
+    public function setCrdate($crdate)
+    {
         $this->crdate = $crdate;
         return $this;
     }
-
 }

--- a/Classes/Domain/Model/AbstractModel.php
+++ b/Classes/Domain/Model/AbstractModel.php
@@ -16,9 +16,7 @@ namespace Pluswerk\MailLogger\Domain\Model;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
- * @method int getTstamp()
- * @method setTstamp(int $value)
- * @method int getCrdate()
+ * Class AbstractModel
  */
 abstract class AbstractModel extends AbstractEntity
 {
@@ -34,28 +32,35 @@ abstract class AbstractModel extends AbstractEntity
     protected $crdate;
 
     /**
-     * dynamic getter and setter
-     *
-     * @param string $methodName
-     * @param array $params
-     * @return mixed|NULL
+     * @return int
      */
-    public function __call($methodName, $params)
-    {
-        $methodPrefix = substr($methodName, 0, 3);
-        $attributeName = lcfirst(substr($methodName, 3));
-        $attributePlName = $attributeName . 's';
-
-        if ($methodPrefix === 'set') {
-            $value = $params[0];
-            $this->{$attributeName} = $value;
-        } elseif ($methodPrefix === 'get') {
-            return $this->{$attributeName};
-        } elseif ($methodPrefix === 'add') {
-            $this->{$attributePlName}->attach($params[0]);
-        } elseif (0 === strpos($methodName, 'remove')) {
-            $this->{$attributePlName}->detach($params[0]);
-        }
-        return null;
+    public function getTstamp(): int {
+        return $this->tstamp;
     }
+
+    /**
+     * @param int $tstamp
+     * @return self
+     */
+    public function setTstamp($tstamp) {
+        $this->tstamp = $tstamp;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCrdate(): int {
+        return $this->crdate;
+    }
+
+    /**
+     * @param int $crdate
+     * @return self
+     */
+    public function setCrdate($crdate) {
+        $this->crdate = $crdate;
+        return $this;
+    }
+
 }

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -14,17 +14,7 @@ namespace Pluswerk\MailLogger\Domain\Model;
  ***/
 
 /**
- * @method setTypoScriptKey(string $string)
- * @method setSubject(string $string)
- * @method setMessage(string $string)
- * @method setMailFrom(string $string)
- * @method setMailTo(string $string)
- * @method setMailCopy(string $string)
- * @method setMailBlindCopy(string $string)
- * @method setResult(string $string)
- * @method setHeaders(string $string)
- * @method string getHeaders()
- * @method setSysLanguageUid(int $var)
+ * Class MailLog
  */
 class MailLog extends AbstractModel
 {
@@ -86,4 +76,165 @@ class MailLog extends AbstractModel
      * @var int
      */
     protected $sysLanguageUid;
+
+    /**
+     * @return string
+     */
+    public function getTypoScriptKey(): string {
+        return $this->typoScriptKey;
+    }
+
+    /**
+     * @param string $typoScriptKey
+     * @return self
+     */
+    public function setTypoScriptKey($typoScriptKey) {
+        $this->typoScriptKey = $typoScriptKey;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject(): string {
+        return $this->subject;
+    }
+
+    /**
+     * @param string $subject
+     * @return self
+     */
+    public function setSubject($subject) {
+        $this->subject = $subject;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     * @return self
+     */
+    public function setMessage($message) {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailFrom(): string {
+        return $this->mailFrom;
+    }
+
+    /**
+     * @param string $mailFrom
+     * @return self
+     */
+    public function setMailFrom($mailFrom) {
+        $this->mailFrom = $mailFrom;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailTo(): string {
+        return $this->mailTo;
+    }
+
+    /**
+     * @param string $mailTo
+     * @return self
+     */
+    public function setMailTo($mailTo) {
+        $this->mailTo = $mailTo;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailCopy(): string {
+        return $this->mailCopy;
+    }
+
+    /**
+     * @param string $mailCopy
+     * @return self
+     */
+    public function setMailCopy($mailCopy) {
+        $this->mailCopy = $mailCopy;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailBlindCopy(): string {
+        return $this->mailBlindCopy;
+    }
+
+    /**
+     * @param string $mailBlindCopy
+     * @return self
+     */
+    public function setMailBlindCopy($mailBlindCopy) {
+        $this->mailBlindCopy = $mailBlindCopy;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeaders(): string {
+        return $this->headers;
+    }
+
+    /**
+     * @param string $headers
+     * @return self
+     */
+    public function setHeaders($headers) {
+        $this->headers = $headers;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResult(): string {
+        return $this->result;
+    }
+
+    /**
+     * @param string $result
+     * @return self
+     */
+    public function setResult($result) {
+        $this->result = $result;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSysLanguageUid(): int {
+        return $this->sysLanguageUid;
+    }
+
+    /**
+     * @param int $sysLanguageUid
+     * @return self
+     */
+    public function setSysLanguageUid($sysLanguageUid) {
+        $this->sysLanguageUid = $sysLanguageUid;
+        return $this;
+    }
+
 }

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -18,7 +18,6 @@ namespace Pluswerk\MailLogger\Domain\Model;
  */
 class MailLog extends AbstractModel
 {
-
     /**
      * @var string
      */
@@ -80,7 +79,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getTypoScriptKey(): string {
+    public function getTypoScriptKey(): string
+    {
         return $this->typoScriptKey;
     }
 
@@ -88,7 +88,8 @@ class MailLog extends AbstractModel
      * @param string $typoScriptKey
      * @return self
      */
-    public function setTypoScriptKey($typoScriptKey) {
+    public function setTypoScriptKey($typoScriptKey)
+    {
         $this->typoScriptKey = $typoScriptKey;
         return $this;
     }
@@ -96,7 +97,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getSubject(): string {
+    public function getSubject(): string
+    {
         return $this->subject;
     }
 
@@ -104,7 +106,8 @@ class MailLog extends AbstractModel
      * @param string $subject
      * @return self
      */
-    public function setSubject($subject) {
+    public function setSubject($subject)
+    {
         $this->subject = $subject;
         return $this;
     }
@@ -112,7 +115,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getMessage(): string {
+    public function getMessage(): string
+    {
         return $this->message;
     }
 
@@ -120,7 +124,8 @@ class MailLog extends AbstractModel
      * @param string $message
      * @return self
      */
-    public function setMessage($message) {
+    public function setMessage($message)
+    {
         $this->message = $message;
         return $this;
     }
@@ -128,7 +133,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getMailFrom(): string {
+    public function getMailFrom(): string
+    {
         return $this->mailFrom;
     }
 
@@ -136,7 +142,8 @@ class MailLog extends AbstractModel
      * @param string $mailFrom
      * @return self
      */
-    public function setMailFrom($mailFrom) {
+    public function setMailFrom($mailFrom)
+    {
         $this->mailFrom = $mailFrom;
         return $this;
     }
@@ -144,7 +151,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getMailTo(): string {
+    public function getMailTo(): string
+    {
         return $this->mailTo;
     }
 
@@ -152,7 +160,8 @@ class MailLog extends AbstractModel
      * @param string $mailTo
      * @return self
      */
-    public function setMailTo($mailTo) {
+    public function setMailTo($mailTo)
+    {
         $this->mailTo = $mailTo;
         return $this;
     }
@@ -160,7 +169,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getMailCopy(): string {
+    public function getMailCopy(): string
+    {
         return $this->mailCopy;
     }
 
@@ -168,7 +178,8 @@ class MailLog extends AbstractModel
      * @param string $mailCopy
      * @return self
      */
-    public function setMailCopy($mailCopy) {
+    public function setMailCopy($mailCopy)
+    {
         $this->mailCopy = $mailCopy;
         return $this;
     }
@@ -176,7 +187,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getMailBlindCopy(): string {
+    public function getMailBlindCopy(): string
+    {
         return $this->mailBlindCopy;
     }
 
@@ -184,7 +196,8 @@ class MailLog extends AbstractModel
      * @param string $mailBlindCopy
      * @return self
      */
-    public function setMailBlindCopy($mailBlindCopy) {
+    public function setMailBlindCopy($mailBlindCopy)
+    {
         $this->mailBlindCopy = $mailBlindCopy;
         return $this;
     }
@@ -192,7 +205,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getHeaders(): string {
+    public function getHeaders(): string
+    {
         return $this->headers;
     }
 
@@ -200,7 +214,8 @@ class MailLog extends AbstractModel
      * @param string $headers
      * @return self
      */
-    public function setHeaders($headers) {
+    public function setHeaders($headers)
+    {
         $this->headers = $headers;
         return $this;
     }
@@ -208,7 +223,8 @@ class MailLog extends AbstractModel
     /**
      * @return string
      */
-    public function getResult(): string {
+    public function getResult(): string
+    {
         return $this->result;
     }
 
@@ -216,7 +232,8 @@ class MailLog extends AbstractModel
      * @param string $result
      * @return self
      */
-    public function setResult($result) {
+    public function setResult($result)
+    {
         $this->result = $result;
         return $this;
     }
@@ -224,7 +241,8 @@ class MailLog extends AbstractModel
     /**
      * @return int
      */
-    public function getSysLanguageUid(): int {
+    public function getSysLanguageUid(): int
+    {
         return $this->sysLanguageUid;
     }
 
@@ -232,9 +250,9 @@ class MailLog extends AbstractModel
      * @param int $sysLanguageUid
      * @return self
      */
-    public function setSysLanguageUid($sysLanguageUid) {
+    public function setSysLanguageUid($sysLanguageUid)
+    {
         $this->sysLanguageUid = $sysLanguageUid;
         return $this;
     }
-
 }

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -21,50 +21,50 @@ class MailLog extends AbstractModel
     /**
      * @var string
      */
-    protected $typoScriptKey;
+    protected $typoScriptKey = '';
 
     /**
      * @var string
      */
-    protected $subject;
+    protected $subject = '';
 
     /**
      * @var string
      */
-    protected $message;
-
-    /**
-     * json encoded
-     *
-     * @var string
-     */
-    protected $mailFrom;
+    protected $message = '';
 
     /**
      * json encoded
      *
      * @var string
      */
-    protected $mailTo;
+    protected $mailFrom = '';
 
     /**
      * json encoded
      *
      * @var string
      */
-    protected $mailCopy;
+    protected $mailTo = '';
 
     /**
      * json encoded
      *
      * @var string
      */
-    protected $mailBlindCopy;
+    protected $mailCopy = '';
+
+    /**
+     * json encoded
+     *
+     * @var string
+     */
+    protected $mailBlindCopy = '';
 
     /**
      * @var string
      */
-    protected $headers;
+    protected $headers = '';
 
     /**
      * @var string
@@ -74,7 +74,7 @@ class MailLog extends AbstractModel
     /**
      * @var int
      */
-    protected $sysLanguageUid;
+    protected $sysLanguageUid = 0;
 
     /**
      * @return string

--- a/Classes/Domain/Model/MailTemplate.php
+++ b/Classes/Domain/Model/MailTemplate.php
@@ -18,7 +18,6 @@ namespace Pluswerk\MailLogger\Domain\Model;
  */
 class MailTemplate extends AbstractModel
 {
-
     /**
      * @var string
      */
@@ -80,7 +79,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getTypoScriptKey(): string {
+    public function getTypoScriptKey(): string
+    {
         return $this->typoScriptKey;
     }
 
@@ -88,7 +88,8 @@ class MailTemplate extends AbstractModel
      * @param string $typoScriptKey
      * @return self
      */
-    public function setTypoScriptKey($typoScriptKey) {
+    public function setTypoScriptKey($typoScriptKey)
+    {
         $this->typoScriptKey = $typoScriptKey;
         return $this;
     }
@@ -96,7 +97,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getTitle(): string {
+    public function getTitle(): string
+    {
         return $this->title;
     }
 
@@ -104,7 +106,8 @@ class MailTemplate extends AbstractModel
      * @param string $title
      * @return self
      */
-    public function setTitle($title) {
+    public function setTitle($title)
+    {
         $this->title = $title;
         return $this;
     }
@@ -112,7 +115,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getSubject(): string {
+    public function getSubject(): string
+    {
         return $this->subject;
     }
 
@@ -120,7 +124,8 @@ class MailTemplate extends AbstractModel
      * @param string $subject
      * @return self
      */
-    public function setSubject($subject) {
+    public function setSubject($subject)
+    {
         $this->subject = $subject;
         return $this;
     }
@@ -128,7 +133,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMessage(): string {
+    public function getMessage(): string
+    {
         return $this->message;
     }
 
@@ -136,7 +142,8 @@ class MailTemplate extends AbstractModel
      * @param string $message
      * @return self
      */
-    public function setMessage($message) {
+    public function setMessage($message)
+    {
         $this->message = $message;
         return $this;
     }
@@ -144,7 +151,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailFromName(): string {
+    public function getMailFromName(): string
+    {
         return $this->mailFromName;
     }
 
@@ -152,7 +160,8 @@ class MailTemplate extends AbstractModel
      * @param string $mailFromName
      * @return self
      */
-    public function setMailFromName($mailFromName) {
+    public function setMailFromName($mailFromName)
+    {
         $this->mailFromName = $mailFromName;
         return $this;
     }
@@ -160,7 +169,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailFromAddress(): string {
+    public function getMailFromAddress(): string
+    {
         return $this->mailFromAddress;
     }
 
@@ -168,7 +178,8 @@ class MailTemplate extends AbstractModel
      * @param string $mailFromAddress
      * @return self
      */
-    public function setMailFromAddress($mailFromAddress) {
+    public function setMailFromAddress($mailFromAddress)
+    {
         $this->mailFromAddress = $mailFromAddress;
         return $this;
     }
@@ -176,7 +187,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailToNames(): string {
+    public function getMailToNames(): string
+    {
         return $this->mailToNames;
     }
 
@@ -184,7 +196,8 @@ class MailTemplate extends AbstractModel
      * @param string $mailToNames
      * @return self
      */
-    public function setMailToNames($mailToNames) {
+    public function setMailToNames($mailToNames)
+    {
         $this->mailToNames = $mailToNames;
         return $this;
     }
@@ -192,7 +205,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailToAddresses(): string {
+    public function getMailToAddresses(): string
+    {
         return $this->mailToAddresses;
     }
 
@@ -200,7 +214,8 @@ class MailTemplate extends AbstractModel
      * @param string $mailToAddresses
      * @return self
      */
-    public function setMailToAddresses($mailToAddresses) {
+    public function setMailToAddresses($mailToAddresses)
+    {
         $this->mailToAddresses = $mailToAddresses;
         return $this;
     }
@@ -208,7 +223,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailCopyAddresses(): string {
+    public function getMailCopyAddresses(): string
+    {
         return $this->mailCopyAddresses;
     }
 
@@ -216,7 +232,8 @@ class MailTemplate extends AbstractModel
      * @param string $mailCopyAddresses
      * @return self
      */
-    public function setMailCopyAddresses($mailCopyAddresses) {
+    public function setMailCopyAddresses($mailCopyAddresses)
+    {
         $this->mailCopyAddresses = $mailCopyAddresses;
         return $this;
     }
@@ -224,7 +241,8 @@ class MailTemplate extends AbstractModel
     /**
      * @return string
      */
-    public function getMailBlindCopyAddresses(): string {
+    public function getMailBlindCopyAddresses(): string
+    {
         return $this->mailBlindCopyAddresses;
     }
 
@@ -232,9 +250,9 @@ class MailTemplate extends AbstractModel
      * @param string $mailBlindCopyAddresses
      * @return self
      */
-    public function setMailBlindCopyAddresses($mailBlindCopyAddresses) {
+    public function setMailBlindCopyAddresses($mailBlindCopyAddresses)
+    {
         $this->mailBlindCopyAddresses = $mailBlindCopyAddresses;
         return $this;
     }
-
 }

--- a/Classes/Domain/Model/MailTemplate.php
+++ b/Classes/Domain/Model/MailTemplate.php
@@ -14,14 +14,7 @@ namespace Pluswerk\MailLogger\Domain\Model;
  ***/
 
 /**
- * @method string getTypoScriptKey()
- * @method string getSubject()
- * @method string getMessage()
- * @method string getMailFromAddress()
- * @method string getMailToNames()
- * @method string getMailToAddresses()
- * @method string getMailCopyAddresses()
- * @method string getMailBlindCopyAddresses()
+ * Class MailTemplate
  */
 class MailTemplate extends AbstractModel
 {
@@ -83,4 +76,165 @@ class MailTemplate extends AbstractModel
      * @var string
      */
     protected $mailBlindCopyAddresses;
+
+    /**
+     * @return string
+     */
+    public function getTypoScriptKey(): string {
+        return $this->typoScriptKey;
+    }
+
+    /**
+     * @param string $typoScriptKey
+     * @return self
+     */
+    public function setTypoScriptKey($typoScriptKey) {
+        $this->typoScriptKey = $typoScriptKey;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     * @return self
+     */
+    public function setTitle($title) {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject(): string {
+        return $this->subject;
+    }
+
+    /**
+     * @param string $subject
+     * @return self
+     */
+    public function setSubject($subject) {
+        $this->subject = $subject;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     * @return self
+     */
+    public function setMessage($message) {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailFromName(): string {
+        return $this->mailFromName;
+    }
+
+    /**
+     * @param string $mailFromName
+     * @return self
+     */
+    public function setMailFromName($mailFromName) {
+        $this->mailFromName = $mailFromName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailFromAddress(): string {
+        return $this->mailFromAddress;
+    }
+
+    /**
+     * @param string $mailFromAddress
+     * @return self
+     */
+    public function setMailFromAddress($mailFromAddress) {
+        $this->mailFromAddress = $mailFromAddress;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailToNames(): string {
+        return $this->mailToNames;
+    }
+
+    /**
+     * @param string $mailToNames
+     * @return self
+     */
+    public function setMailToNames($mailToNames) {
+        $this->mailToNames = $mailToNames;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailToAddresses(): string {
+        return $this->mailToAddresses;
+    }
+
+    /**
+     * @param string $mailToAddresses
+     * @return self
+     */
+    public function setMailToAddresses($mailToAddresses) {
+        $this->mailToAddresses = $mailToAddresses;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailCopyAddresses(): string {
+        return $this->mailCopyAddresses;
+    }
+
+    /**
+     * @param string $mailCopyAddresses
+     * @return self
+     */
+    public function setMailCopyAddresses($mailCopyAddresses) {
+        $this->mailCopyAddresses = $mailCopyAddresses;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMailBlindCopyAddresses(): string {
+        return $this->mailBlindCopyAddresses;
+    }
+
+    /**
+     * @param string $mailBlindCopyAddresses
+     * @return self
+     */
+    public function setMailBlindCopyAddresses($mailBlindCopyAddresses) {
+        $this->mailBlindCopyAddresses = $mailBlindCopyAddresses;
+        return $this;
+    }
+
 }

--- a/Classes/Domain/Model/MailTemplate.php
+++ b/Classes/Domain/Model/MailTemplate.php
@@ -21,60 +21,60 @@ class MailTemplate extends AbstractModel
     /**
      * @var string
      */
-    protected $typoScriptKey;
+    protected $typoScriptKey = '';
 
     /**
      * @var string
      */
-    protected $title;
+    protected $title = '';
 
     /**
      * @var string
      */
-    protected $subject;
+    protected $subject = '';
 
     /**
      * @var string
      */
-    protected $message;
+    protected $message = '';
 
     /**
      * @var string
      */
-    protected $mailFromName;
+    protected $mailFromName = '';
 
     /**
      * @var string
      */
-    protected $mailFromAddress;
-
-    /**
-     * comma separated
-     *
-     * @var string
-     */
-    protected $mailToNames;
+    protected $mailFromAddress = '';
 
     /**
      * comma separated
      *
      * @var string
      */
-    protected $mailToAddresses;
+    protected $mailToNames = '';
 
     /**
      * comma separated
      *
      * @var string
      */
-    protected $mailCopyAddresses;
+    protected $mailToAddresses = '';
 
     /**
      * comma separated
      *
      * @var string
      */
-    protected $mailBlindCopyAddresses;
+    protected $mailCopyAddresses = '';
+
+    /**
+     * comma separated
+     *
+     * @var string
+     */
+    protected $mailBlindCopyAddresses = '';
 
     /**
      * @return string


### PR DESCRIPTION
Bugfix TYPO3 v9.4
TYPO3 Backend > Admin Tools > Mail Log
Error: Cannot access protected property Pluswerk\MailLogger\Domain\Model\MailLog::$tstamp
File: ./Resources/Private/Backend/Partials/MailLog.html
Solved by getter and setter instead of __call method.