### PR TITLE
Bugfix TypoScriptService & not included TypoScript

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Extbase\Service\TypoScriptService;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 
 /**
  */
@@ -55,7 +55,7 @@ class ConfigurationUtility
             if ($fullTypoScript === null) {
                 $fullTypoScript = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
             }
-            /** @var \TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService */
+            /** @var TypoScriptService $typoScriptService */
             $typoScriptService = $objectManager->get(TypoScriptService::class);
             self::$currentModuleConfiguration = $typoScriptService->convertTypoScriptArrayToPlainArray($fullTypoScript['module.']['tx_maillogger.']);
         }

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -57,6 +57,9 @@ class ConfigurationUtility
             }
             /** @var TypoScriptService $typoScriptService */
             $typoScriptService = $objectManager->get(TypoScriptService::class);
+            if (empty($fullTypoScript['module.']['tx_maillogger.'])) {
+                throw new \Exception('Constants and setup TypoScript are not included!');
+            }
             self::$currentModuleConfiguration = $typoScriptService->convertTypoScriptArrayToPlainArray($fullTypoScript['module.']['tx_maillogger.']);
         }
         return self::$currentModuleConfiguration[$key];


### PR DESCRIPTION
Error occurs if you create a new mail template.
- TypoScriptService moved
- If User has not included TypoScript files a new error will thrown
