### PR TITLE
[TASK] Define non-shared models in Services.yaml

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -9,6 +9,10 @@ services:
     exclude:
       - '../Classes/Logging/LoggingTransport.php'
 
+  Pluswerk\MailLogger\Domain\Model\:
+    resource: '../Classes/Domain/Model/*'
+    shared: false
+
   TYPO3\CMS\Core\Mail\MailerInterface:
     alias: Pluswerk\MailLogger\Logging\MailerExtender
   TYPO3\CMS\Core\Mail\Mailer:


### PR DESCRIPTION
- in case of sending 2 emails (user and admin), just one was logged
- because just one mailLog instance was created, instead of two