### PR TITLE
Include default typoscript installation-wide

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,13 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') || die();
+
+// Add default TypoScript
+ExtensionManagementUtility::addTypoScriptConstants(
+    "@import 'EXT:mail_logger/Configuration/TypoScript/constants.typoscript'"
+);
+ExtensionManagementUtility::addTypoScriptSetup(
+    "@import 'EXT:mail_logger/Configuration/TypoScript/setup.typoscript'"
+);


### PR DESCRIPTION
Currently the dashboard template cannot be loaded, see #35. This fixes it.

Temporary workaround: patch via composer-patches:

```
        "pluswerk/mail-logger": {
            "Fix backend view path": "https://github.com/dimitri-koenig/mail_logger/pull/1.patch"
        }
```

Fixes #35 