### PR TITLE
Update mail log if exception is thrown

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.php }}-composer-
-      - run: composer require typo3/minimal="^${{ matrix.typo3 }}" --dev
+      - run: composer require typo3/cms-frontend="^${{ matrix.typo3 }}" --dev
       - run: composer install --no-interaction --no-progress
       - run: ./vendor/bin/grumphp run --ansi
       - run: composer test

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -43,7 +43,8 @@ class MailLog extends AbstractModel
 
     protected string $result = 'Not send until now';
 
-    protected int $status = MailStatus::UNKNOWN->value;
+    //protected int $status = MailStatus::UNKNOWN->value; // if PHP 8.2 is lowest PHP version
+    protected int $status = 0;
 
     protected string $debug = '';
 

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Pluswerk\MailLogger\Domain\Model;
 
+use Pluswerk\MailLogger\Dto\MailStatus;
+
 class MailLog extends AbstractModel
 {
-    final public const MAIL_STATUS_UNKNOWN = 0;
-    final public const MAIL_STATUS_SENT_OK = 1;
-    final public const MAIL_STATUS_NOT_SENT = 2;
-    final public const MAIL_STATUS_DEFAULT = self::MAIL_STATUS_UNKNOWN;
-
     /**
      * @var int
      */
@@ -46,7 +43,9 @@ class MailLog extends AbstractModel
 
     protected string $result = 'Not send until now';
 
-    protected int $status = self::MAIL_STATUS_DEFAULT;
+    protected int $status = MailStatus::UNKNOWN->value;
+
+    protected string $debug = '';
 
     protected int $sysLanguageUid = 0;
 
@@ -164,7 +163,18 @@ class MailLog extends AbstractModel
         $this->status = $status;
         return $this;
     }
-    
+
+    public function getDebug(): string
+    {
+        return $this->debug;
+    }
+
+    public function setDebug(string $debug): self
+    {
+        $this->debug = $debug;
+        return $this;
+    }
+
     public function getSysLanguageUid(): int
     {
         return $this->sysLanguageUid;

--- a/Classes/Domain/Model/MailLog.php
+++ b/Classes/Domain/Model/MailLog.php
@@ -6,6 +6,11 @@ namespace Pluswerk\MailLogger\Domain\Model;
 
 class MailLog extends AbstractModel
 {
+    final public const MAIL_STATUS_UNKNOWN = 0;
+    final public const MAIL_STATUS_SENT_OK = 1;
+    final public const MAIL_STATUS_NOT_SENT = 2;
+    final public const MAIL_STATUS_DEFAULT = self::MAIL_STATUS_UNKNOWN;
+
     /**
      * @var int
      */
@@ -40,6 +45,8 @@ class MailLog extends AbstractModel
     protected string $headers = '';
 
     protected string $result = 'Not send until now';
+
+    protected int $status = self::MAIL_STATUS_DEFAULT;
 
     protected int $sysLanguageUid = 0;
 
@@ -147,6 +154,17 @@ class MailLog extends AbstractModel
         return $this;
     }
 
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function setStatus(int $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+    
     public function getSysLanguageUid(): int
     {
         return $this->sysLanguageUid;

--- a/Classes/Domain/Repository/MailLogRepository.php
+++ b/Classes/Domain/Repository/MailLogRepository.php
@@ -112,6 +112,7 @@ class MailLogRepository extends Repository
                 ->set('mail_copy', $this->anonymizeSymbol)
                 ->set('mail_blind_copy', $this->anonymizeSymbol)
                 ->set('headers', $this->anonymizeSymbol)
+                ->set('debug', $this->anonymizeSymbol)
                 ->where($queryBuilder->expr()->lte('crdate', $queryBuilder->createNamedParameter($timestamp)))
                 ->execute();
         }

--- a/Classes/Dto/MailStatus.php
+++ b/Classes/Dto/MailStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pluswerk\MailLogger\Dto;
+
+enum MailStatus: int
+{
+    case UNKNOWN = 0;
+    case SENT_OK = 1;
+    case NOT_SENT = 2;
+    case QUEUED = 3;
+}

--- a/Classes/Dto/SendResult.php
+++ b/Classes/Dto/SendResult.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pluswerk\MailLogger\Dto;
+
+use Symfony\Component\Mailer\SentMessage;
+use Throwable;
+use TYPO3\CMS\Core\Core\Environment;
+
+final readonly class SendResult
+{
+    public function __construct(
+        public string $result,
+        public MailStatus $status,
+        public string $debug = '',
+        public ?SentMessage $sentMessage = null,
+        public ?Throwable $throwable = null,
+    ) {
+    }
+
+    public function getDebugMessage(): string
+    {
+        $result = '';
+        if ($this->debug) {
+            $result .= '# Debug: ' . PHP_EOL . $this->debug . PHP_EOL;
+        }
+
+        if ($this->throwable) {
+            $result .= '# Exception: ' . PHP_EOL . $this->throwable->getMessage() . PHP_EOL;
+            if (!Environment::getContext()->isProduction()) {
+                $result .= $this->throwable->getTraceAsString() . PHP_EOL;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Dto/SendResult.php
+++ b/Classes/Dto/SendResult.php
@@ -8,14 +8,14 @@ use Symfony\Component\Mailer\SentMessage;
 use Throwable;
 use TYPO3\CMS\Core\Core\Environment;
 
-final readonly class SendResult
+final class SendResult
 {
     public function __construct(
-        public string $result,
-        public MailStatus $status,
-        public string $debug = '',
-        public ?SentMessage $sentMessage = null,
-        public ?Throwable $throwable = null,
+        public readonly string $result,
+        public readonly MailStatus $status,
+        public readonly string $debug = '',
+        public readonly ?SentMessage $sentMessage = null,
+        public readonly ?Throwable $throwable = null,
     ) {
     }
 

--- a/Classes/Logging/LoggingTransport.php
+++ b/Classes/Logging/LoggingTransport.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pluswerk\MailLogger\Logging;
 
+use Stringable;
+use Throwable;
 use Pluswerk\MailLogger\Domain\Model\MailLog;
 use Pluswerk\MailLogger\Domain\Model\TemplateBasedMailMessage;
 use Pluswerk\MailLogger\Domain\Repository\MailLogRepository;
@@ -26,7 +28,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
-class LoggingTransport implements TransportInterface, \Stringable
+class LoggingTransport implements TransportInterface, Stringable
 {
     public function __construct(protected TransportInterface $originalTransport)
     {
@@ -87,7 +89,7 @@ class LoggingTransport implements TransportInterface, \Stringable
             }
 
             return new SendResult($result, $status, $sendMessage->getDebug(), $sendMessage);
-        } catch (\Throwable $throwable) {
+        } catch (Throwable $throwable) {
             return new SendResult('Email not sent. Error: ' . $throwable->getMessage(), MailStatus::NOT_SENT, throwable: $throwable);
         }
     }

--- a/Classes/Logging/LoggingTransport.php
+++ b/Classes/Logging/LoggingTransport.php
@@ -7,17 +7,24 @@ namespace Pluswerk\MailLogger\Logging;
 use Pluswerk\MailLogger\Domain\Model\MailLog;
 use Pluswerk\MailLogger\Domain\Model\TemplateBasedMailMessage;
 use Pluswerk\MailLogger\Domain\Repository\MailLogRepository;
+use Pluswerk\MailLogger\Dto\MailStatus;
+use Pluswerk\MailLogger\Dto\SendResult;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\NullTransport;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Transport\Transports;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\AbstractMultipartPart;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\TextPart;
 use Symfony\Component\Mime\RawMessage;
+use TYPO3\CMS\Core\Mail\DelayedTransportInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 class LoggingTransport implements TransportInterface, \Stringable
 {
@@ -37,36 +44,52 @@ class LoggingTransport implements TransportInterface, \Stringable
         $mailLogRepository->add($mailLog);
         GeneralUtility::makeInstance(PersistenceManager::class)->persistAll();
 
-        /** @var string $result */
-        $result = '';
-        /** @var int $status */
-        $status = MailLog::MAIL_STATUS_UNKNOWN;
-        $exceptionWasThrown = null;
-        $sendMessage = null;
-        try {
-            $sendMessage = $this->originalTransport->send($message, $envelope);
-            if ($sendMessage !== null) {
-                $result = 'Email sent';
-                $status = MailLog::MAIL_STATUS_SENT_OK;
-            } else {
-                $result = 'Email not sent';
-                $status = MailLog::MAIL_STATUS_NOT_SENT;
-            }
-        } catch (\Throwable $e) {
-            $result = 'Email not sent. Error: ' . $e->getMessage();
-            $status = MailLog::MAIL_STATUS_NOT_SENT;
-            $exceptionWasThrown = $e;
-        }
+
+        $sendResult = $this->originalSend($message, $envelope);
 
         // write result to log after send
         $this->assignMailLog($mailLog, $message);
-        $mailLog->setResult($result);
-        $mailLog->setStatus($status);
+        $mailLog->setResult($sendResult->result);
+        $mailLog->setStatus($sendResult->status->value);
+        $mailLog->setDebug($sendResult->getDebugMessage());
+
         $mailLogRepository->update($mailLog);
-        if ($exceptionWasThrown) {
-            throw $exceptionWasThrown;
+        GeneralUtility::makeInstance(PersistenceManager::class)->persistAll();
+
+        if ($sendResult->throwable) {
+            throw $sendResult->throwable;
         }
-        return $sendMessage;
+
+        return $sendResult->sentMessage;
+    }
+
+    private function originalSend(RawMessage $message, Envelope $envelope = null): SendResult
+    {
+        try {
+            $sendMessage = $this->originalTransport->send($message, $envelope);
+            if (!$sendMessage) {
+                return new SendResult('Email not sent', MailStatus::NOT_SENT);
+            }
+
+            $result = 'Email sent';
+            $status = MailStatus::SENT_OK;
+            if (
+                $this->originalTransport instanceof DelayedTransportInterface
+                || $this->originalTransport instanceof SendmailTransport
+            ) {
+                $result = 'Email queued';
+                $status = MailStatus::QUEUED;
+            }
+
+            if ($this->originalTransport instanceof NullTransport) {
+                $result = 'Email Nulled (NullTransport)';
+                $status = MailStatus::NOT_SENT;
+            }
+
+            return new SendResult($result, $status, $sendMessage->getDebug(), $sendMessage);
+        } catch (\Throwable $throwable) {
+            return new SendResult('Email not sent. Error: ' . $throwable->getMessage(), MailStatus::NOT_SENT, throwable: $throwable);
+        }
     }
 
     public function __toString(): string
@@ -105,7 +128,8 @@ class LoggingTransport implements TransportInterface, \Stringable
             return $messageString;
         }
 
-        $body = $part instanceof TextPart && $part->getMediaType() === 'text' ? $part->getBody() : $part->asDebugString();
+        $body = $part instanceof TextPart && $part->getMediaType() === 'text' ? $part->getBody() : $part->asDebugString(
+        );
         $body = str_replace(["\t", "\r"], '', $body);
         if ($part->getMediaSubtype() === 'plain') {
             $body = str_replace(PHP_EOL, '<br>', $body);
@@ -125,8 +149,8 @@ class LoggingTransport implements TransportInterface, \Stringable
             ', ',
             array_map(
                 static fn(Address $address): string => $address->getName() . ' <' . $address->getAddress() . '>',
-                $addresses
-            )
+                $addresses,
+            ),
         );
     }
 

--- a/Classes/Utility/MailUtility.php
+++ b/Classes/Utility/MailUtility.php
@@ -18,7 +18,7 @@ class MailUtility
      * @param string $key The TypoScript key of your template
      * @param int|null $languageUid The language uid
      * @param array<array-key, mixed> $viewParameters This is necessary if you use Fluid for your mail fields
-     * @throws \Exception
+     * @throws Exception
      */
     public static function getMailByKey(string $key, int $languageUid = null, array $viewParameters = []): TemplateBasedMailMessage
     {
@@ -38,7 +38,7 @@ class MailUtility
      *
      * @param int $mailTemplateId The identifier uid of your template
      * @param array<array-key, mixed> $viewParameters This is necessary if you use Fluid for your mail fields
-     * @throws \Exception
+     * @throws Exception
      * @deprecated will be removed. use \Pluswerk\MailLogger\Utility\MailUtility::getMailByKey instead
      */
     public static function getMailById(int $mailTemplateId, array $viewParameters = []): TemplateBasedMailMessage

--- a/Classes/ViewHelpers/Pagination/UriViewHelper.php
+++ b/Classes/ViewHelpers/Pagination/UriViewHelper.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Pluswerk\MailLogger\ViewHelpers\Pagination;
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
-use TYPO3\CMS\Extbase\Service\ExtensionService;
-use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 class UriViewHelper extends AbstractTagBasedViewHelper

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -8,6 +8,7 @@ services:
     resource: '../Classes'
     exclude:
       - '../Classes/Logging/LoggingTransport.php'
+      - '../Classes/Dto/'
 
   Pluswerk\MailLogger\Domain\Model\:
     resource: '../Classes/Domain/Model/*'

--- a/Configuration/TCA/tx_maillogger_domain_model_maillog.php
+++ b/Configuration/TCA/tx_maillogger_domain_model_maillog.php
@@ -137,6 +137,16 @@ return [
                 'eval' => 'trim',
             ],
         ],
+        'status' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:mail_logger/Resources/Private/Language/locallang_db.xlf:tx_maillogger_domain_model_maillog.status',
+            'config' => [
+                'readOnly' => 1,
+                'type' => 'input',
+                'size' => 10,
+                'eval' => 'trim',
+            ],
+        ],
         'headers' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:mail_logger/Resources/Private/Language/locallang_db.xlf:tx_maillogger_domain_model_maillog.headers',

--- a/Configuration/TCA/tx_maillogger_domain_model_maillog.php
+++ b/Configuration/TCA/tx_maillogger_domain_model_maillog.php
@@ -15,7 +15,7 @@ return [
         'iconfile' => 'EXT:mail_logger/Resources/Public/Icons/MailLog.svg',
     ],
     'types' => [
-        '1' => ['showitem' => 'sys_language_uid,typo_script_key,subject,message,mail_from,mail_to,mail_copy,mail_blind_copy,result'],
+        '1' => ['showitem' => 'sys_language_uid,typo_script_key,subject,message,mail_from,mail_to,mail_copy,mail_blind_copy,result,debug'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],
@@ -145,6 +145,14 @@ return [
                 'type' => 'input',
                 'size' => 10,
                 'eval' => 'trim',
+            ],
+        ],
+        'debug' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:mail_logger/Resources/Private/Language/locallang_db.xlf:tx_maillogger_domain_model_maillog.debug',
+            'config' => [
+                'readOnly' => 1,
+                'type' => 'text',
             ],
         ],
         'headers' => [

--- a/Resources/Private/Backend/Partials/MailLog.html
+++ b/Resources/Private/Backend/Partials/MailLog.html
@@ -14,6 +14,9 @@
               <mailLogger:translate id="module.mailLog.date"/>
             </th>
             <th>
+              <mailLogger:translate id="module.mailLog.status"/>
+            </th>
+            <th>
               <mailLogger:translate id="module.mailLog.typoScriptKey"/>
             </th>
             <th>
@@ -33,6 +36,14 @@
             <tr>
               <td>
                 <f:format.date format="Y-m-d H:i:s">{item.crdate}</f:format.date>
+              </td>
+              <td>
+                <f:if condition="{item.status} == 1">
+                  <core:icon identifier="actions-check-circle" size="medium" title="ok"/>
+                </f:if>
+                <f:if condition="{item.status} == 2">
+                  <core:icon identifier="actions-exclamation-circle" size="medium" title="E-Mail not sent"/>
+                </f:if>
               </td>
               <td>{item.typoScriptKey}</td>
               <td>{item.subject}</td>

--- a/Resources/Private/Backend/Partials/MailLog.html
+++ b/Resources/Private/Backend/Partials/MailLog.html
@@ -39,10 +39,13 @@
               </td>
               <td>
                 <f:if condition="{item.status} == 1">
-                  <core:icon identifier="actions-check-circle" size="medium" title="ok"/>
+                  <core:icon identifier="actions-check-circle-alt" size="medium" title="ok"/>
                 </f:if>
                 <f:if condition="{item.status} == 2">
                   <core:icon identifier="actions-exclamation-circle" size="medium" title="E-Mail not sent"/>
+                </f:if>
+                <f:if condition="{item.status} == 3">
+                  <core:icon identifier="actions-circle-half" size="medium" title="E-Mail queued"/>
                 </f:if>
               </td>
               <td>{item.typoScriptKey}</td>

--- a/Resources/Private/Backend/Templates/MailLog/Show.html
+++ b/Resources/Private/Backend/Templates/MailLog/Show.html
@@ -64,5 +64,13 @@
       </div>
     </div>
   </div>
+  <div class="col col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading"><mailLogger:translate id="module.mailLog.title.debug"/></div>
+      <div class="panel-body maillogger-panel-body">
+        <f:format.nl2br>{mailLog.debug}</f:format.nl2br>
+      </div>
+    </div>
+  </div>
 
 </div>

--- a/Resources/Private/Backend/Templates/MailLog/Show.html
+++ b/Resources/Private/Backend/Templates/MailLog/Show.html
@@ -30,7 +30,7 @@
           <mailLogger:translate id="module.mailLog.typoScriptKey"/>: {mailLog.typoScriptKey}<br />
         </f:if>
         <mailLogger:translate id="module.mailLog.sysLanguageUid"/>: <mailLogger:sysLanguageUid uid="{mailLog.sysLanguageUid}" /><br />
-        <mailLogger:translate id="module.mailLog.result"/>: {mailLog.result}<br />
+        <mailLogger:translate id="module.mailLog.result_message"/>: {mailLog.result}<br />
         <mailLogger:translate id="module.mailLog.date"/>: <f:format.date format="d.m.Y H:i:s">{mailLog.crdate}</f:format.date><br />
       </div>
     </div>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -39,6 +39,9 @@
       <trans-unit id="tx_maillogger.module.mailLog.title.headers">
         <target>Header</target>
       </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.title.debug">
+        <target>Debug</target>
+      </trans-unit>
       <trans-unit id="tx_maillogger.module.mailLog.details">
         <target>Details</target>
       </trans-unit>
@@ -76,7 +79,7 @@
         <target>Datum</target>
       </trans-unit>
       <trans-unit id="tx_maillogger.module.mailLog.status">
-        <source>Result</source>
+        <target>Result</target>
       </trans-unit>
 
       <!-- Model: Task -->

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -54,6 +54,12 @@
       <trans-unit id="tx_maillogger.module.mailLog.result">
         <target>Akzeptierte Empfänger</target>
       </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.result_message">
+        <target>Ergebnis</target>
+      </trans-unit>
+      <trans-unit id="tx_maillogger_domain_model_maillog.status">
+        <target>Status</target>
+      </trans-unit>
       <trans-unit id="tx_maillogger.module.mailLog.mailFrom">
         <target>Von</target>
       </trans-unit>
@@ -68,6 +74,9 @@
       </trans-unit>
       <trans-unit id="tx_maillogger.module.mailLog.date">
         <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.status">
+        <source>Result</source>
       </trans-unit>
 
       <!-- Model: Task -->

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -69,6 +69,9 @@
       <trans-unit id="tx_maillogger.module.mailLog.date">
         <source>Date</source>
       </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.status">
+        <source>Result</source>
+      </trans-unit>
 
       <!-- Model: MailTemplate -->
       <trans-unit id="tx_maillogger_domain_model_mailtemplate">
@@ -141,6 +144,12 @@
       </trans-unit>
       <trans-unit id="tx_maillogger_domain_model_maillog.result">
         <source>Result</source>
+      </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.result_message">
+        <source>Result</source>
+      </trans-unit>
+      <trans-unit id="tx_maillogger_domain_model_maillog.status">
+        <source>Status</source>
       </trans-unit>
       <trans-unit id="tx_maillogger_domain_model_maillog.headers">
         <source>Headers</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -39,6 +39,9 @@
       <trans-unit id="tx_maillogger.module.mailLog.title.headers">
         <source>Headers</source>
       </trans-unit>
+      <trans-unit id="tx_maillogger.module.mailLog.title.debug">
+        <source>Debug</source>
+      </trans-unit>
       <trans-unit id="tx_maillogger.module.mailLog.details">
         <source>Details</source>
       </trans-unit>

--- a/Tests/Functional/MailLogRepository/AbstractMailLogRepositoryTest.php
+++ b/Tests/Functional/MailLogRepository/AbstractMailLogRepositoryTest.php
@@ -4,6 +4,7 @@
 
 namespace Pluswerk\MailLogger\Tests\Functional\MailLogRepository;
 
+use ReflectionObject;
 use DateTime;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Persistence\Generic\Exception\NotImplementedException;
@@ -48,8 +49,8 @@ abstract class AbstractMailLogRepositoryTest extends FunctionalTestCase
                     'anonymizeAfter' => $mailLogRepository->getAnonymizeAfter(),
                     'anonymizeSymbol' => $mailLogRepository->getAnonymizeSymbol(),
                 ],
-                JSON_THROW_ON_ERROR
-            )
+                JSON_THROW_ON_ERROR,
+            ),
         );
     }
 
@@ -214,6 +215,10 @@ abstract class AbstractMailLogRepositoryTest extends FunctionalTestCase
             unset($data['tstamp'], $data['crdate']);
         }
 
+        if ($data) {
+            ksort($data);
+        }
+
         $this->assertMatchesJsonSnapshot(json_encode($data, JSON_THROW_ON_ERROR));
     }
 
@@ -225,6 +230,6 @@ abstract class AbstractMailLogRepositoryTest extends FunctionalTestCase
      */
     protected function callInaccessibleMethod(object $object, string $name): mixed
     {
-        return (new \ReflectionObject($object))->getMethod($name)->invokeArgs($object, []);
+        return (new ReflectionObject($object))->getMethod($name)->invokeArgs($object, []);
     }
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testAdd__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testAdd__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey558",
     "subject": "subject558",
     "message": "message558",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail558@test.test",
     "headers": "headers558",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testAnonymizeAll__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testAnonymizeAll__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey7894",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "***",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testUpdateWithDelayAnonymize__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testUpdateWithDelayAnonymize__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey2345",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testUpdate__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/Anonymize7daysLifeTime30daysTest__testUpdate__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey555",
     "subject": "subject555",
     "message": "message555",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail555@test.test",
     "headers": "headers555",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testAdd__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testAdd__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey558",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testAnonymizeAll__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testAnonymizeAll__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey7894",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "***",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testCleanupDatabase__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testCleanupDatabase__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey789",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testUpdateWithDelayAnonymize__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testUpdateWithDelayAnonymize__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey2345",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testUpdate__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/AnonymizeDirectlyLifeTimeEmptyTest__testUpdate__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey555",
     "subject": "***",
     "message": "***",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "***",
     "headers": "***",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testAdd__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testAdd__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey558",
     "subject": "subject558",
     "message": "message558",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail558@test.test",
     "headers": "headers558",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testAnonymizeAll__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testAnonymizeAll__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey7894",
     "subject": "subject7894",
     "message": "message7894",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail7894@test.test",
     "headers": "headers7894",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testUpdateWithDelayAnonymize__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testUpdateWithDelayAnonymize__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey2345",
     "subject": "subject2345",
     "message": "message2345",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail2345@test.test",
     "headers": "headers2345",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testUpdate__1.json
+++ b/Tests/Functional/MailLogRepository/__snapshots__/NoAnonymizeLifeTime1minTest__testUpdate__1.json
@@ -1,4 +1,6 @@
 {
+    "uid": 1,
+    "pid": 1,
     "typoScriptKey": "typoscriptKey555",
     "subject": "subject555",
     "message": "message555",
@@ -8,7 +10,7 @@
     "mailBlindCopy": "mail555@test.test",
     "headers": "headers555",
     "result": "Not send until now",
-    "sysLanguageUid": 0,
-    "uid": 1,
-    "pid": 1
+    "status": 0,
+    "debug": "",
+    "sysLanguageUid": 0
 }

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
   },
   "require-dev": {
     "ext-json": "*",
-    "pluswerk/grumphp-config": "^6.9.0",
-    "saschaegerer/phpstan-typo3": "^1.9.0",
-    "spatie/phpunit-snapshot-assertions": "^4.2.16",
-    "ssch/typo3-rector": "^1.4.1",
-    "typo3/testing-framework": "^7.0.4"
+    "pluswerk/grumphp-config": "^6.10.0",
+    "saschaegerer/phpstan-typo3": "^1.10.1",
+    "spatie/phpunit-snapshot-assertions": "^4.2.17",
+    "ssch/typo3-rector": "^1.8.1",
+    "typo3/testing-framework": "^7.1.0"
   },
   "replace": {
     "pluswerk/mail_logger": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   },
   "require-dev": {
     "ext-json": "*",
-    "pluswerk/grumphp-config": "^6.10.0",
+    "pluswerk/grumphp-config": "^7.1.0",
     "saschaegerer/phpstan-typo3": "^1.10.1",
     "spatie/phpunit-snapshot-assertions": "^4.2.17",
-    "ssch/typo3-rector": "^1.8.1",
+    "ssch/typo3-rector": "^2.6.4",
     "typo3/testing-framework": "^7.1.0"
   },
   "replace": {
@@ -54,7 +54,8 @@
   },
   "scripts": {
     "post-update-cmd": [
-      "@composer bump --dev-only"
+      "@composer bump --dev-only",
+      "@composer normalize"
     ],
     "test": "vendor/bin/phpunit --color=always",
     "test:update": "vendor/bin/phpunit --color=always -d --update-snapshots"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,14 +8,10 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Markus Hölzle',
     'author_email' => 'markus.hoelzle@pluswerk.ag',
     'state' => 'stable',
-    'internal' => '',
-    'uploadfolder' => '0',
-    'createDirs' => '',
-    'clearCacheOnLoad' => 0,
     'version' => \Composer\InstalledVersions::getPrettyVersion('pluswerk/mail-logger'),
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-12.99.99',
+            'typo3' => '11.0.0-13.2.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -60,7 +60,8 @@ CREATE TABLE tx_maillogger_domain_model_maillog (
 	mail_copy varchar(500) DEFAULT '' NOT NULL,
 	mail_blind_copy varchar(500) DEFAULT '' NOT NULL,
 	result varchar(500) DEFAULT '' NOT NULL,
-  status  int(11) unsigned DEFAULT '0' NOT NULL,
+	debug text NOT NULL,
+	status int(11) unsigned DEFAULT '0' NOT NULL,
 	headers text NOT NULL,
 	sys_language_uid int(11) DEFAULT '0' NOT NULL,
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -60,6 +60,7 @@ CREATE TABLE tx_maillogger_domain_model_maillog (
 	mail_copy varchar(500) DEFAULT '' NOT NULL,
 	mail_blind_copy varchar(500) DEFAULT '' NOT NULL,
 	result varchar(500) DEFAULT '' NOT NULL,
+  status  int(11) unsigned DEFAULT '0' NOT NULL,
 	headers text NOT NULL,
 	sys_language_uid int(11) DEFAULT '0' NOT NULL,
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,7 @@
     </report>
   </coverage>
   <php>
+    <const name="TYPO3" value="1"/>
     <const name="TYPO3_MODE" value="BE"/>
     <ini name="display_errors" value="1"/>
     <env name="TYPO3_CONTEXT" value="Testing"/>

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use PLUS\GrumPHPConfig\RectorSettings;
 use Rector\Config\RectorConfig;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
@@ -15,7 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->cacheDirectory('./var/cache/rector');
 
     $rectorConfig->paths(
-        array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php|html|typoscript)$'")))
+        array_filter(explode("\n", (string)shell_exec("git ls-files | xargs ls -d 2>/dev/null | grep -E '\.(php)$'")))
     );
 
     // define sets of rules
@@ -37,7 +36,8 @@ return static function (RectorConfig $rectorConfig): void {
              * rector should not touch these files
              */
             __DIR__ . '/ext_emconf.php',
-            FinalizeClassesWithoutChildrenRector::class,
+            //__DIR__ . '/src/Example',
+            //__DIR__ . '/src/Example.php',
         ]
     );
 };


### PR DESCRIPTION
Resolves: #57

-----

1. Catch exception on send() and update tx_maillogger_domain_model_maillog
2. In case of exception write $->getMessage() to tx_maillogger_domain_model_maillog
3. Mark logs with error in "Mail Logger" list view by using an icon
4. Instead of showing "Accepted recipients: 1", name the field "Result" and show error message, if error message exists
5. add extra field "status" with numeric value

This might still benefit from fine tuning:

* make it pretty
* localize some more texts

**Example output:**

list:

![image](https://github.com/user-attachments/assets/a5ef1587-64c3-4142-be24-ed1c7178244f)

detail:

![image](https://github.com/user-attachments/assets/12972820-ef1d-4eb1-b4bf-135a7cbc85fd)

