### PR TITLE
Add PHP 8.4 support for TYPO3 v12

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: mail-logger
 type: php
 docroot: ""
-php_version: "8.3"
+php_version: "8.4"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []
@@ -62,7 +62,7 @@ corepack_enable: false
 
 # host_xhgui_port: 8142
 # Can be used to change the host binding port of the xhgui
-# application. Rarely used; only when port conflict and 
+# application. Rarely used; only when port conflict and
 # bind_all_ports is used (normally with router disabled)
 
 # xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"

--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -9,8 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
         typo3: [ '11', '12' ]
+        exclude:
+          - php: '8.3'
+            typo3: '11'
+          - php: '8.4'
+            typo3: '11'
     steps:
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2

--- a/Classes/Domain/Repository/MailTemplateRepository.php
+++ b/Classes/Domain/Repository/MailTemplateRepository.php
@@ -24,7 +24,7 @@ class MailTemplateRepository extends Repository
         $this->setDefaultQuerySettings($querySettings);
     }
 
-    public function findOneByTypoScriptKeyAndLanguage(string $typoScriptKey, int $languageUid = null): ?MailTemplate
+    public function findOneByTypoScriptKeyAndLanguage(string $typoScriptKey, ?int $languageUid = null): ?MailTemplate
     {
         $mailTemplate = null;
         if ($languageUid === null) {

--- a/Classes/Logging/LoggingTransport.php
+++ b/Classes/Logging/LoggingTransport.php
@@ -34,7 +34,7 @@ class LoggingTransport implements TransportInterface, Stringable
     {
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         $this->fixTcaIfNotPresentIsUsedInInstallTool();
 
@@ -70,7 +70,7 @@ class LoggingTransport implements TransportInterface, Stringable
         return $this->originalTransport;
     }
 
-    private function originalSend(RawMessage $message, Envelope $envelope = null): SendResult
+    private function originalSend(RawMessage $message, ?Envelope $envelope = null): SendResult
     {
         try {
             $sendMessage = $this->originalTransport->send($message, $envelope);

--- a/Classes/Logging/MailerExtender.php
+++ b/Classes/Logging/MailerExtender.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Core\Mail\Mailer;
  */
 class MailerExtender extends Mailer
 {
-    public function __construct(TransportInterface $transport = null, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(?TransportInterface $transport = null, ?EventDispatcherInterface $eventDispatcher = null)
     {
         parent::__construct($transport, $eventDispatcher);
         $this->transport = new LoggingTransport($this->transport);

--- a/Classes/Utility/MailUtility.php
+++ b/Classes/Utility/MailUtility.php
@@ -20,7 +20,7 @@ class MailUtility
      * @param array<array-key, mixed> $viewParameters This is necessary if you use Fluid for your mail fields
      * @throws Exception
      */
-    public static function getMailByKey(string $key, int $languageUid = null, array $viewParameters = []): TemplateBasedMailMessage
+    public static function getMailByKey(string $key, ?int $languageUid = null, array $viewParameters = []): TemplateBasedMailMessage
     {
         $mail = GeneralUtility::makeInstance(TemplateBasedMailMessage::class);
         $templateRepository = GeneralUtility::makeInstance(MailTemplateRepository::class);

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "docs": "https://github.com/pluswerk/mail_logger/blob/master/Readme.md"
   },
   "require": {
-    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
     "composer-runtime-api": "^2",
     "typo3/cms-core": "^11.5.0 || ^12.4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,12 @@
   },
   "require-dev": {
     "ext-json": "*",
-    "pluswerk/grumphp-config": "^7.2.0",
-    "saschaegerer/phpstan-typo3": "^1.10.2",
-    "spatie/phpunit-snapshot-assertions": "^4.2.17",
-    "ssch/typo3-rector": "^2.14.3",
-    "typo3/testing-framework": "^7.1.1"
+    "phpunit/phpunit": "^10.5.54",
+    "pluswerk/grumphp-config": "^7.2.0 || ^10.1.3",
+    "saschaegerer/phpstan-typo3": "^1.10.2 || ^2.1.1",
+    "spatie/phpunit-snapshot-assertions": "^4.2.17 || ^5.2.2",
+    "ssch/typo3-rector": "^2.15.2 || ^3.6.2",
+    "typo3/testing-framework": "^7.1.1 || ^8.2.7 || ^9"
   },
   "replace": {
     "pluswerk/mail_logger": "self.version",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,15 +6,10 @@
   bootstrap="Tests/FunctionalTestsBootstrap.php"
   cacheResult="false"
   colors="true"
-  convertErrorsToExceptions="true"
-  convertWarningsToExceptions="true"
-  forceCoversAnnotation="false"
   stopOnError="false"
   stopOnFailure="false"
   stopOnIncomplete="false"
   stopOnSkipped="false"
-  verbose="false"
-  beStrictAboutTestsThatDoNotTestAnything="false"
   failOnWarning="true"
   executionOrder="random"
   processIsolation="true"
@@ -25,6 +20,11 @@
       <html outputDirectory="var/test-coverage/"/>
     </report>
   </coverage>
+  <source>
+    <include>
+      <directory>Classes</directory>
+    </include>
+  </source>
   <php>
     <const name="TYPO3" value="1"/>
     <const name="TYPO3_MODE" value="BE"/>
@@ -40,6 +40,7 @@
   <testsuites>
     <testsuite name="Functional">
       <directory>Tests/Functional/</directory>
+      <exclude>Tests/Functional/MailLogRepository/AbstractMailLogRepositoryTest.php</exclude>
     </testsuite>
   </testsuites>
   <logging>


### PR DESCRIPTION
Resolves: #71

Todos:

* probably check with PHP 8.4 should be added to GitHub workflow, but not for v11