### PR TITLE
Aus 850 new icon

### DIFF
--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'dependencies' => ['core', 'backend'],
     'imports' => [

--- a/Configuration/TCA/tx_maillogger_domain_model_maillog.php
+++ b/Configuration/TCA/tx_maillogger_domain_model_maillog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:mail_logger/Resources/Private/Language/locallang_db.xlf:tx_maillogger_domain_model_maillog',

--- a/Configuration/TCA/tx_maillogger_domain_model_mailtemplate.php
+++ b/Configuration/TCA/tx_maillogger_domain_model_mailtemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Pluswerk\MailLogger\Wizard\MailTemplate;
 
 return [

--- a/Resources/Public/Icons/Extension.svg
+++ b/Resources/Public/Icons/Extension.svg
@@ -1,37 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="50 110 233 233" style="enable-background:new 50 110 233 233;" xml:space="preserve">
-  <style type="text/css">
-    .envelope-base{fill:#FFE633;}
-    .envelope-flap{fill:#FFE633;}
-    .envelope-shadow{fill:#BCA869;opacity:0.5;}
-    .document{fill:#FFFFFF;}
-    .corner-fold{fill:#B3D4FC;opacity:0.8;}
-    .log-line{fill:#5A7CA6;}
-  </style>
-  <!-- Define clipPath for envelope-shadow -->
-  <clipPath id="envelopeBaseClip">
-    <rect x="50" y="166.5" width="233" height="120" rx="20" />
-  </clipPath>
-  <!-- Define clipPath for envelope-shadow shape -->
-  <clipPath id="envelopeShadowClip">
-    <polygon points="166.5,286.5 50,166.5 283,166.5" />
-  </clipPath>
-  <!-- Envelope base -->
-  <rect class="envelope-base" x="50" y="166.5" width="233" height="120" rx="20"/>
-  <!-- Envelope shadow for depth, clipped to envelope base -->
-  <polygon class="envelope-shadow" points="166.5,286.5 50,166.5 283,166.5" clip-path="url(#envelopeBaseClip)"/>
-  <!-- Envelope flap at the top -->
-  <polygon class="envelope-flap" points="166.5,186.5 60,166.5 273,166.5"  clip-path="url(#envelopeBaseClip)"/>
-  <!-- Document (log) overlay, clipped to envelope-shadow shape -->
-  <rect class="document" x="90" y="196.5" width="153" height="80" rx="8" clip-path="url(#envelopeShadowClip)"/>
-  <!-- Document corner fold, clipped to document shape -->
-  <clipPath id="documentClip">
-    <rect x="90" y="196.5" width="153" height="80" rx="8" clip-path="url(#envelopeShadowClip)"/>
-  </clipPath>
-  <polygon class="corner-fold" points="225,196.5 243,196.5 243,214.5" clip-path="url(#documentClip)"/>
-  <!-- Log lines -->
-  <rect class="log-line" x="105" y="211.5" width="80" height="7" rx="2" clip-path="url(#envelopeShadowClip)"/>
-  <rect class="log-line" x="105" y="226.5" width="65" height="7" rx="2" clip-path="url(#envelopeShadowClip)"/>
-  <rect class="log-line" x="105" y="241.5" width="70" height="7" rx="2" clip-path="url(#envelopeShadowClip)"/>
-  <rect class="log-line" x="105" y="256.5" width="60" height="7" rx="2" clip-path="url(#envelopeShadowClip)"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 233 233" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="Maillogger">
+        <g id="Hell">
+            <g transform="matrix(0.25549,0,0,0.25549,-6.135016,237.201581)">
+                <path d="M160,-160C138,-160 119.167,-167.833 103.5,-183.5C87.833,-199.167 80,-218 80,-240L80,-720C80,-742 87.833,-760.833 103.5,-776.5C119.167,-792.167 138,-800 160,-800L800,-800C822,-800 840.833,-792.167 856.5,-776.5C872.167,-760.833 880,-742 880,-720L880,-240C880,-218 872.167,-199.167 856.5,-183.5C840.833,-167.833 822,-160 800,-160L160,-160ZM480,-440L160,-640L160,-240L800,-240L800,-640L480,-440ZM480,-520L800,-720L160,-720L480,-520ZM160,-240L160,-720L160,-240Z" style="fill:rgb(255,240,0);fill-rule:nonzero;"/>
+            </g>
+            <g transform="matrix(25.68627,0,0,25.68627,-378.988353,10.419541)">
+                <circle cx="22.054" cy="6.108" r="1.378" style="fill:rgb(255,0,224);"/>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/Resources/Public/Icons/Extension.svg
+++ b/Resources/Public/Icons/Extension.svg
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 233 233" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g id="Maillogger">
-        <g id="Hell">
-            <g transform="matrix(0.25549,0,0,0.25549,-6.135016,237.201581)">
-                <path d="M160,-160C138,-160 119.167,-167.833 103.5,-183.5C87.833,-199.167 80,-218 80,-240L80,-720C80,-742 87.833,-760.833 103.5,-776.5C119.167,-792.167 138,-800 160,-800L800,-800C822,-800 840.833,-792.167 856.5,-776.5C872.167,-760.833 880,-742 880,-720L880,-240C880,-218 872.167,-199.167 856.5,-183.5C840.833,-167.833 822,-160 800,-160L160,-160ZM480,-440L160,-640L160,-240L800,-240L800,-640L480,-440ZM480,-520L800,-720L160,-720L480,-520ZM160,-240L160,-720L160,-240Z" style="fill:rgb(255,240,0);fill-rule:nonzero;"/>
-            </g>
-            <g transform="matrix(25.68627,0,0,25.68627,-378.988353,10.419541)">
-                <circle cx="22.054" cy="6.108" r="1.378" style="fill:rgb(255,0,224);"/>
-            </g>
+    <style>
+        .dark-only { display: none; }
+
+        @media (prefers-color-scheme: dark) {
+            html:not([data-color-scheme="light"]) .light-only { display: none; }
+            html:not([data-color-scheme="light"]) .dark-only { display: block; }
+        }
+
+        html[data-color-scheme="dark"] .light-only { display: none; }
+        html[data-color-scheme="dark"] .dark-only { display: block; }
+
+        html[data-color-scheme="light"] .light-only { display: block; }
+        html[data-color-scheme="light"] .dark-only { display: none; }
+    </style>
+    <g id="Maillogger-light" class="light-only">
+        <g transform="matrix(0.25549,0,0,0.25549,-6.135016,237.201581)">
+            <path d="M160,-160C138,-160 119.167,-167.833 103.5,-183.5C87.833,-199.167 80,-218 80,-240L80,-720C80,-742 87.833,-760.833 103.5,-776.5C119.167,-792.167 138,-800 160,-800L800,-800C822,-800 840.833,-792.167 856.5,-776.5C872.167,-760.833 880,-742 880,-720L880,-240C880,-218 872.167,-199.167 856.5,-183.5C840.833,-167.833 822,-160 800,-160L160,-160ZM480,-440L160,-640L160,-240L800,-240L800,-640L480,-440ZM480,-520L800,-720L160,-720L480,-520ZM160,-240L160,-720L160,-240Z" style="fill:black;fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(25.68627,0,0,25.68627,-378.988353,10.419541)">
+            <circle cx="22.054" cy="6.108" r="1.378" style="fill:rgb(255,0,224);"/>
+        </g>
+    </g>
+    <g id="Maillogger-dark" class="dark-only">
+        <g transform="matrix(0.25549,0,0,0.25549,-6.135016,237.201581)">
+            <path d="M160,-160C138,-160 119.167,-167.833 103.5,-183.5C87.833,-199.167 80,-218 80,-240L80,-720C80,-742 87.833,-760.833 103.5,-776.5C119.167,-792.167 138,-800 160,-800L800,-800C822,-800 840.833,-792.167 856.5,-776.5C872.167,-760.833 880,-742 880,-720L880,-240C880,-218 872.167,-199.167 856.5,-183.5C840.833,-167.833 822,-160 800,-160L160,-160ZM480,-440L160,-640L160,-240L800,-240L800,-640L480,-440ZM480,-520L800,-720L160,-720L480,-520ZM160,-240L160,-720L160,-240Z" style="fill:rgb(255,240,0);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(25.68627,0,0,25.68627,-378.988353,10.419541)">
+            <circle cx="22.054" cy="6.108" r="1.378" style="fill:rgb(255,0,224);"/>
         </g>
     </g>
 </svg>

--- a/Tests/Functional/MailLogRepository/Anonymize7daysLifeTime30daysTest.php
+++ b/Tests/Functional/MailLogRepository/Anonymize7daysLifeTime30daysTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pluswerk\MailLogger\Tests\Functional\MailLogRepository;
 
 use Override;

--- a/Tests/Functional/MailLogRepository/AnonymizeDirectlyLifeTimeEmptyTest.php
+++ b/Tests/Functional/MailLogRepository/AnonymizeDirectlyLifeTimeEmptyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pluswerk\MailLogger\Tests\Functional\MailLogRepository;
 
 use Override;

--- a/Tests/Functional/MailLogRepository/NoAnonymizeLifeTime1minTest.php
+++ b/Tests/Functional/MailLogRepository/NoAnonymizeLifeTime1minTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pluswerk\MailLogger\Tests\Functional\MailLogRepository;
 
 use Override;

--- a/config/system/settings.php
+++ b/config/system/settings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use TYPO3\CMS\Core\Crypto\PasswordHashing\Argon2iPasswordHash;
 use TYPO3\CMS\Core\Log\Writer\FileWriter;
 use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Pluswerk\MailLogger\Logging\MailerExtender;
 use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;


### PR DESCRIPTION
Adds a new extension icon that automatically adapts to the TYPO3 backend's dark/light color scheme.
The SVG ships both variants in a single file, toggled via CSS using prefers-color-scheme and TYPO3's html[data-color-scheme] attribute.